### PR TITLE
chore: output build to vitepress directory

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -11,4 +11,7 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  build: {
+    outDir: ".vitepress/dist",
+  },
 })


### PR DESCRIPTION
## Summary
- output build artifacts into `.vitepress/dist`

## Testing
- `pnpm run build`
- `pnpm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_6895feef2140832da725f8b9032a2c98