### PR TITLE
Use pages_build_output_dir for Pages deploy

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,3 +1,3 @@
 [pages]
-build_output_dir = "dist"
+pages_build_output_dir = "dist"
 build_command = "npm run build"


### PR DESCRIPTION
## Summary
- configure Pages to use `pages_build_output_dir` and `build_command`

## Testing
- `npx wrangler pages deploy` *(fails: configuration file missing `pages_build_output_dir`)*

------
https://chatgpt.com/codex/tasks/task_e_68961167c540832d8a0b463a26635530