### PR TITLE
fix: output directory

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -12,6 +12,6 @@ export default defineConfig({
     },
   },
   build: {
-    outDir: ".vitepress/dist",
+    outDir: "dist",
   },
 })


### PR DESCRIPTION
## Summary
- remove VitePress output dir in Vite config so build emits to `dist`

## Testing
- `pnpm run build`
- `pnpm test --run` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68961fce0c04832db2ecf9242ab781c5